### PR TITLE
remove redundant maven test command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         version: ${{ matrix.jdk }}
         impl: ${{ matrix.impl }}
     - name: Run Tests
-      run: mvn -ntp -U -B -fae clean install test
+      run: mvn -ntp -U -B -fae clean install
     - uses: actions/upload-artifact@v2
       if: failure()
       with:


### PR DESCRIPTION
The extra test command causes tests to run twice, which can cause errors.