### PR TITLE
fix for Value too long for column EXECUTIONEXCEPTION

### DIFF
--- a/src/main/java/org/jberet/jpa/repository/TableColumnsJpa.java
+++ b/src/main/java/org/jberet/jpa/repository/TableColumnsJpa.java
@@ -56,7 +56,7 @@ public final class TableColumnsJpa {
     public static final String WRITERCHECKPOINTINFO = "WRITERCHECKPOINTINFO";
     public static final String PARTITION_EXECUTION = "PARTITION_EXECUTION";
     
-    static final int EXECUTION_EXCEPTION_LENGTH_LIMIT = 2048;
+    public static final int EXECUTION_EXCEPTION_LENGTH_LIMIT = 2048;
 
     static String formatException(final Exception exception) {
         if (exception == null) {

--- a/src/main/java/org/jberet/jpa/repository/entity/StepExecutionJpa.java
+++ b/src/main/java/org/jberet/jpa/repository/entity/StepExecutionJpa.java
@@ -91,6 +91,7 @@ public class StepExecutionJpa implements Serializable {
     @Column(name = EXITSTATUS)
     private String exitStatus;
     
+    @Lob
     @Column(name = EXECUTIONEXCEPTION)
     private String executionException;
     

--- a/src/main/java/org/jberet/jpa/repository/entity/StepExecutionJpa.java
+++ b/src/main/java/org/jberet/jpa/repository/entity/StepExecutionJpa.java
@@ -35,6 +35,7 @@ import static org.jberet.jpa.repository.TableColumnsJpa.BATCHSTATUS;
 import static org.jberet.jpa.repository.TableColumnsJpa.COMMITCOUNT;
 import static org.jberet.jpa.repository.TableColumnsJpa.ENDTIME;
 import static org.jberet.jpa.repository.TableColumnsJpa.EXECUTIONEXCEPTION;
+import static org.jberet.jpa.repository.TableColumnsJpa.EXECUTION_EXCEPTION_LENGTH_LIMIT;
 import static org.jberet.jpa.repository.TableColumnsJpa.EXITSTATUS;
 import static org.jberet.jpa.repository.TableColumnsJpa.FILTERCOUNT;
 import static org.jberet.jpa.repository.TableColumnsJpa.JOBEXECUTIONID;
@@ -92,7 +93,7 @@ public class StepExecutionJpa implements Serializable {
     private String exitStatus;
     
     @Lob
-    @Column(name = EXECUTIONEXCEPTION)
+    @Column(name = EXECUTIONEXCEPTION, length = EXECUTION_EXCEPTION_LENGTH_LIMIT)
     private String executionException;
     
     @Lob


### PR DESCRIPTION
@chengfang hi !

I noticed that sometime I get an exception, Value too long for column, probably because the stacktrace is longer.

Without the @Lob annotation, max length is 255.
According to the EXECUTION_EXCEPTION_LENGTH_LIMIT, defined also in the jdbc implementation, this limit should be 2048.

I didn't notice this before, can you merge please ?